### PR TITLE
docs: add guideline for naming single child resources in CDK

### DIFF
--- a/rules/cdk-design-patterns.md
+++ b/rules/cdk-design-patterns.md
@@ -34,6 +34,7 @@
 - Include the resource type in the logical ID
 - Use descriptive property names
 - Use generated resource names instead of physical names whenever possible.
+- If the construct has only one or a single main child resource, call it "Resource" to use the defaultChild functionality of CDK
 
 ### Composition and Inheritence
 


### PR DESCRIPTION
# Add guideline for naming single child resources in CDK

This PR adds a new guideline to the CDK design patterns documentation regarding the naming convention for constructs with a single main child resource.

## Description

When creating CDK constructs that wrap a single main resource or have one primary child resource, it's beneficial to follow a consistent naming pattern that leverages CDK's built-in `defaultChild` functionality. This PR adds guidance to name such resources as "Resource" within the construct.

### Why this change?

1. **Consistency with CDK Patterns**: The AWS CDK framework provides a `defaultChild` property that allows easy access to the primary resource of a construct. By naming the main child resource as "Resource", we align with this pattern.

2. **Better Developer Experience**: When using `node.defaultChild`, developers can easily access the underlying primary resource without needing to know specific property names or internal structure.

3. **Clearer Code Structure**: This naming convention makes it immediately obvious which resource is the main component of the construct.


## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New rule (non-breaking addition)
- [ ] Rule update (non-breaking change to existing rules)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Rule category affected
- [ ] CDK Project Structure
- [ ] CDK TypeScript
- [X] CDK Design Patterns
- [ ] CDK Security & Compliance
- [ ] CDK Constructs
- [ ] Testing
- [ ] Other (please specify)

## How Has This Been Tested?
None

